### PR TITLE
Update devise.rb

### DIFF
--- a/devise.rb
+++ b/devise.rb
@@ -126,16 +126,7 @@ after_bundle do
   ########################################
   rails_command "db:migrate"
   generate("devise:views")
-  gsub_file(
-    "app/views/devise/registrations/new.html.erb",
-    "<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>",
-    "<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>"
-  )
-  gsub_file(
-    "app/views/devise/sessions/new.html.erb",
-    "<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>",
-    "<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: :false }) do |f| %>"
-  )
+
   link_to = <<~HTML
     <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
   HTML


### PR DESCRIPTION
Removing the two `gsub_file` adding a `data: { turbo: :false }` on the forms for new session and new registration.

Apps created with or without this change in the simple forms for new session and new registration, behave exactly the same way : flashes/redirections/errors in form works in both case.
